### PR TITLE
Update to nix 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ docs = ["iou"]
 iou = ["iou_"]
 
 [dependencies]
-nix = "0.19"
+nix = "0.21"
 libc = "0.2"
 
 iou_ = { package = "iou", version = "0.3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use std::cmp::Ordering;
 use std::convert::TryInto;
 
 use nix::errno::Errno;
-use nix::unistd::{Pid, Uid};
+pub use nix::unistd::{Pid, Uid};
 
 /// An I/O priority, either associated with a class and per-class data, or the standard priority.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]


### PR DESCRIPTION
This also publicly re-exports the nix types that are part of the public api of ioprio. This way I don't need to manually track nix as a dependency in a version that's compatible with ioprio.

Since types of the nix crate are part of the public api of ioprio this change needs to be released as 0.2.0 :)